### PR TITLE
remove `key` warning

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,6 +73,7 @@ class App extends React.Component {
   buildQuote(movie, sub, index, showModal = false) {
     return (
       <Quote
+      key={movie.id+sub.time}
       context={this.buildContext(movie, index)}
       sub={sub.sub}
       subIndex={index}


### PR DESCRIPTION
This is because of this code `[this.buildQuote(this.state.linkQuote.movie, this.state.linkQuote.sub, this.state.linkQuote.index, true)]` which is an array, so it needs a key.